### PR TITLE
Portability and allow to specify a custom python install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(area)
 
-cmake_minimum_required(VERSION 2.4)
+cmake_minimum_required(VERSION 2.8)
 
 # Turn compiler warnings up to 11, at least with gcc.  
 if (CMAKE_BUILD_TOOL MATCHES "make")
@@ -23,16 +23,63 @@ if (NOT BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif(NOT BUILD_TYPE)
 
-# this figures out the Python include directories and adds them to the
-# header file search path
-execute_process(
-    COMMAND python-config --includes
-    COMMAND sed -r "s/-I//g; s/ +/;/g"
-    COMMAND tr -d '\n'
-    OUTPUT_VARIABLE Python_Includes
-)
-include_directories(${Python_Includes})
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+option(PYTHON_DIR "Python executional dir")
+
+# -------------- start python search code --------------
+if ("${PYTHON_DIR}" STREQUAL "OFF")
+  # we havent set any specific python, use system defaults
+  set(PYTHON_DIR "")
+
+else("${PYTHON_DIR}" STREQUAL "OFF")
+  # we have set a specific python install, correct accordingly
+  # such as macports for example
+  set(PYTHON_DIR "${PYTHON_DIR}/")
+
+  # this figures out the Python include directories and adds them to the
+  # header file search path so that find_package(PythonLibs) searches in the correct place
+  execute_process(
+    COMMAND ${PYTHON_DIR}python-config --includes OUTPUT_VARIABLE Python_Includes
+  )
+  string(REGEX REPLACE "-I([^;\n ]+).*" "\\1" Python_Includes ${Python_Includes})
+  MESSAGE(STATUS " PYTHON_INCLUDES = ${Python_Includes}")
+
+  # need to set these when we have multipe pythons installed
+  set(PYTHON_INCLUDE_DIR ${Python_Includes})
+  execute_process(
+    COMMAND ${PYTHON_DIR}python-config --prefix OUTPUT_VARIABLE Python_Prefix
+  )
+  string(REGEX REPLACE "([^;\n ]+).*" "\\1" Python_Prefix ${Python_Prefix})
+  MESSAGE(STATUS " PYTHON_prefix = ${Python_Prefix}")
+
+  # find the library name of selected python install
+  find_library(PYTHON_LIBRARY NAMES python python2.7 python2.6 python3.0
+                 python3.1 python3.2 python 3.3 python3.4 python3.5
+               PATHS "${Python_Prefix}/lib/" NO_DEFAULT_PATH NO_SYSTEM_ENVIRONMENT_PATH)
+
+  MESSAGE(STATUS " PYTHON_LIBRARY = ${PYTHON_LIBRARY}")
+
+  if (PYTHON_LIBRARY MATCHES PYTHON_LIBRARY-NOTFOUND)
+    MESSAGE(FATAL_ERROR "*** Python lib not found!")
+  endif()
+
+endif("${PYTHON_DIR}" STREQUAL "OFF")
+
+find_package ( PythonLibs REQUIRED)
+
+message(STATUS "PYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}")
+message(STATUS "PYTHON_LIBRARIES:FILEPATH=${PYTHON_LIBRARIES}")
+message(STATUS "PYTHON_INCLUDE_DIR:FILEPATH=${PYTHON_INCLUDE_DIR}")
+message(STATUS "PYTHON_FRAMEWORK_INCLUDES=${PYTHON_FRAMEWORK_INCLUDES}")
+message(STATUS "PYTHONLIBS_VERSION_STRING=${PYTHONLIBS_VERSION_STRING}")
+message(STATUS "Python_FRAMEWORKS=${Python_FRAMEWORKS}")
+
+get_filename_component(PYTHON_LIBRARY_DIR ${PYTHON_LIBRARY} DIRECTORY)
+message(STATUS "PYTHON_LIBRARY_DIR:FILEPATH=${PYTHON_LIBRARY_DIR}")
+
+include_directories(${PYTHON_INCLUDE_DIR})
+link_directories(${PYTHON_LIBRARY_DIR})
+
+# ----------------------- END Python search code ---------------------
 
 find_package( Boost COMPONENTS python REQUIRED)  # find BOOST and boost-python
 if(Boost_FOUND)
@@ -43,6 +90,9 @@ if(Boost_FOUND)
     MESSAGE(STATUS "boost_LIBRARY_DIRS is: " ${Boost_LIBRARY_DIRS})
     MESSAGE(STATUS "Boost_LIBRARIES is: " ${Boost_LIBRARIES})    
 endif()
+
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # this defines the source-files
 set(AREA_SRC
@@ -89,7 +139,7 @@ add_library(
     MODULE
     ${AREA_SRC}
 )
-target_link_libraries(area ${Boost_LIBRARIES} ) 
+target_link_libraries(area ${Boost_LIBRARIES} ${PYTHON_LIBRARY})
 set_target_properties(area PROPERTIES PREFIX "") 
 
 
@@ -97,10 +147,11 @@ set_target_properties(area PROPERTIES PREFIX "")
 # this figures out where to install the Python modules
 #
 execute_process(
-    COMMAND python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()"
+    COMMAND "${PYTHON_DIR}python" -c "from distutils.sysconfig import get_python_lib; print get_python_lib()"
     OUTPUT_VARIABLE Python_site_packages
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+MESSAGE(STATUS "${PYTHON_DIR}python")
 MESSAGE(STATUS "Python libraries will be installed to: " ${Python_site_packages})
 
 # this installs the python library


### PR DESCRIPTION
Like: 

```
cmake ... -DPYTHON_DIR=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/bin/   ...
```

Tested on macports and build using clang-602.0.53 (OS X 10.9)

Fix should also make cmake config more protable as it no longer rely
on unix sed commands (make windows compile?)
